### PR TITLE
Make Drawer items consistent with Navbar items.

### DIFF
--- a/frontend/src/Navbar/Navbar.js
+++ b/frontend/src/Navbar/Navbar.js
@@ -159,17 +159,22 @@ class Navbar extends React.Component {
               onKeyDown={this.closeDrawer}
             >
               <List>
-                {paths.map((path, i) => (
-                  <ListItem
-                    exact
-                    key={path.stem}
-                    component={DrawerLink}
-                    to={paths[i].to}
-                    divider
-                  >
-                    {path.label}
-                  </ListItem>
-                ))}
+                {paths.map((path, i) => {
+                  if (i > 0 && i < 4 && !isLoggedIn) {
+                    return null;
+                  }
+                  return (
+                    <ListItem
+                      exact
+                      key={path.stem}
+                      component={DrawerLink}
+                      to={paths[i].to}
+                      divider
+                    >
+                      {path.label}
+                    </ListItem>
+                  );
+                })}
               </List>
             </div>
           </Drawer>


### PR DESCRIPTION
The side drawer (in mobile mode) was showing all navigation items even when user wasn't logged in.