### PR TITLE
Fix Material-UI console warning

### DIFF
--- a/frontend/src/Navbar/Navbar.js
+++ b/frontend/src/Navbar/Navbar.js
@@ -145,11 +145,11 @@ class Navbar extends React.Component {
                 indicatorColor="secondary"
                 fullWidth={false}
               >
-                <TabMod idx={0} exact classes={classes} />
-                {isLoggedIn && <TabMod idx={1} classes={classes} />}
-                {isLoggedIn && <TabMod idx={2} classes={classes} />}
-                {isLoggedIn && <TabMod idx={3} classes={classes} />}
-                <TabMod idx={4} classes={classes} />
+                <TabMod value={0} exact classes={classes} />
+                {isLoggedIn && <TabMod value={1} classes={classes} />}
+                {isLoggedIn && <TabMod value={2} classes={classes} />}
+                {isLoggedIn && <TabMod value={3} classes={classes} />}
+                <TabMod value={4} classes={classes} />
               </Tabs>
             )}
             <Greeting>Hi,&nbsp;{username}</Greeting>

--- a/frontend/src/Navbar/Navbar.js
+++ b/frontend/src/Navbar/Navbar.js
@@ -62,6 +62,11 @@ class Navbar extends React.Component {
     // eslint-disable-next-line
     if (nextProps.location.pathname === '/') {
       this.handleIndicator(null, 0);
+    } else {
+      const { pathname } = nextProps.location;
+      const stem = pathname.split('/')[1];
+
+      this.handleIndicator(null, paths.findIndex(path => path.stem === stem));
     }
   }
 

--- a/frontend/src/Navbar/TabMod.js
+++ b/frontend/src/Navbar/TabMod.js
@@ -8,17 +8,17 @@ import paths from './config';
 
 const propTypes = {
   classes: PropTypes.object.isRequired,
-  idx: PropTypes.number.isRequired,
+  value: PropTypes.number.isRequired,
 };
 
-const TabMod = ({ classes, idx, ...props }) => (
+const TabMod = ({ classes, value, ...props }) => (
   <Tab
     component={NavLinkStyled}
     disableRipple
-    key={idx}
-    to={paths[idx].to}
-    label={paths[idx].label}
+    to={paths[value].to}
+    label={paths[value].label}
     classes={{ root: classes.fullHeight }}
+    value={value}
     {...props}
   />
 );


### PR DESCRIPTION
Fix Material-UI warning in console.
Props passed to child component was overwritten and Material-UI defaulted to child's position index instead of passed down index.

Fixes #105 (Navbar now listens to location updates other than `/`).