### PR TITLE
fix: article edit snackbar text on auto hide

### DIFF
--- a/frontend/src/ArticleEdit/ArticleEdit.js
+++ b/frontend/src/ArticleEdit/ArticleEdit.js
@@ -125,7 +125,7 @@ class ArticleEdit extends React.Component {
 
   handleClose = () => {
     this.setState(() => ({
-      message: { show: false },
+      message: { ...this.state.message, show: false },
     }));
   };
 


### PR DESCRIPTION
the snackbar text on successful save changed to "something went wrong" during the hide animation