### PR TITLE
Fix/mobile sidebar revamp

### DIFF
--- a/frontend/src/CMSContainer/CMSContainer.js
+++ b/frontend/src/CMSContainer/CMSContainer.js
@@ -1,21 +1,12 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
 
-// Material UI components
-import Drawer from 'material-ui/Drawer';
-import IconButton from 'material-ui/IconButton';
-import MenuIcon from '@material-ui/icons/Menu';
-
 import { getArticleList } from './actions';
 import ContentArea from '../ContentArea';
 import Sidebar from '../Sidebar';
 import { Wrapper } from './styled';
 
-const BREAK_MOBILE = 900;
-
 export default class CMSContainer extends React.Component {
-  static nop = () => {};
-
   state = {
     articleList: [],
   };
@@ -24,89 +15,16 @@ export default class CMSContainer extends React.Component {
     getArticleList().then(articleList => {
       this.setState({ articleList });
     });
-
-    window.addEventListener('resize', this.handleResize);
-    this.handleResize();
   };
-
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
-  }
-
-  handleResize = () => {
-    const { mobile } = this.state;
-    const windowWidth = window.innerWidth;
-
-    if (mobile && windowWidth > BREAK_MOBILE) {
-      this.setState(() => ({
-        mobile: false,
-      }));
-    } else if (!mobile && windowWidth <= BREAK_MOBILE) {
-      this.setState(() => ({
-        mobile: true,
-      }));
-    }
-  };
-
-  openDrawer = () => {
-    this.setState(() => ({
-      open: true,
-    }));
-  };
-
-  closeDrawer = () => {
-    this.setState(() => ({
-      open: false,
-    }));
-  };
-
-  renderDrawer = (component, open) => (
-    <Drawer open={open} onClose={this.closeDrawer}>
-      <div
-        style={{ width: 250 }}
-        tabIndex={0}
-        role="button"
-        onClick={this.closeDrawer}
-        onKeyDown={this.closeDrawer}
-      />
-      {component}
-    </Drawer>
-  );
 
   render() {
-    const { articleList, mobile, open } = this.state;
+    const { articleList } = this.state;
 
     return (
       <Wrapper>
-        {mobile && (
-          <IconButton
-            color="inherit"
-            aria-label="Menu"
-            onClick={this.openDrawer}
-          >
-            <MenuIcon />
-          </IconButton>
-        )}
         <Route
           path="/cms/:id?"
-          render={p =>
-            mobile ? (
-              this.renderDrawer(
-                <Sidebar
-                  {...p}
-                  onArticleSelect={this.closeDrawer}
-                  articles={articleList}
-                />,
-                open
-              )
-            ) : (
-              <Sidebar
-                {...p}
-                articles={articleList}
-                onArticleSelect={CMSContainer.nop}
-              />
-            )
-          }
+          render={p => <Sidebar {...p} articles={articleList} />}
         />
         <Route
           exact

--- a/frontend/src/CMSContainer/CMSContainer.js
+++ b/frontend/src/CMSContainer/CMSContainer.js
@@ -14,6 +14,8 @@ import { Wrapper } from './styled';
 const BREAK_MOBILE = 900;
 
 export default class CMSContainer extends React.Component {
+  static nop = () => {};
+
   state = {
     articleList: [],
   };
@@ -98,7 +100,11 @@ export default class CMSContainer extends React.Component {
                 open
               )
             ) : (
-              <Sidebar {...p} articles={articleList} />
+              <Sidebar
+                {...p}
+                articles={articleList}
+                onArticleSelect={CMSContainer.nop}
+              />
             )
           }
         />

--- a/frontend/src/CMSContainer/CMSContainer.js
+++ b/frontend/src/CMSContainer/CMSContainer.js
@@ -66,8 +66,9 @@ export default class CMSContainer extends React.Component {
         role="button"
         onClick={this.closeDrawer}
         onKeyDown={this.closeDrawer}
-      />
-      {component}
+      >
+        {component}
+      </div>
     </Drawer>
   );
 

--- a/frontend/src/CMSContainer/CMSContainer.js
+++ b/frontend/src/CMSContainer/CMSContainer.js
@@ -66,9 +66,8 @@ export default class CMSContainer extends React.Component {
         role="button"
         onClick={this.closeDrawer}
         onKeyDown={this.closeDrawer}
-      >
-        {component}
-      </div>
+      />
+      {component}
     </Drawer>
   );
 
@@ -90,7 +89,14 @@ export default class CMSContainer extends React.Component {
           path="/cms/:id?"
           render={p =>
             mobile ? (
-              this.renderDrawer(<Sidebar {...p} articles={articleList} />, open)
+              this.renderDrawer(
+                <Sidebar
+                  {...p}
+                  onArticleSelect={this.closeDrawer}
+                  articles={articleList}
+                />,
+                open
+              )
             ) : (
               <Sidebar {...p} articles={articleList} />
             )

--- a/frontend/src/CMSContainer/CMSContainer.js
+++ b/frontend/src/CMSContainer/CMSContainer.js
@@ -12,10 +12,14 @@ export default class CMSContainer extends React.Component {
   };
 
   componentDidMount = () => {
-    getArticleList().then(articleList => {
+    this.getArticles().then(articleList => {
       this.setState({ articleList });
     });
   };
+  // eslint-disable-next-line
+  getArticles() {
+    return getArticleList();
+  }
 
   render() {
     const { articleList } = this.state;

--- a/frontend/src/CMSContainer/CMSContainer.test.js
+++ b/frontend/src/CMSContainer/CMSContainer.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { BrowserRouter as Router } from 'react-router-dom';
+
+import CMSContainer from './CMSContainer';
+
+it('should render container', () => {
+  const getArticleList = jest
+    .spyOn(CMSContainer.prototype, 'getArticles')
+    .mockImplementation(() => new Promise(resolve => resolve([])));
+  const comp = mount(
+    <Router>
+      <CMSContainer />
+    </Router>
+  );
+  return Promise.resolve(() => {
+    comp.update();
+    expect(getArticleList).toHaveBeenCalled();
+    expect(comp.find('Sidebar').length).toBe(1);
+    expect(comp.find('ContentArea').length).toBe(1);
+  });
+});

--- a/frontend/src/Sidebar/Collapsible.js
+++ b/frontend/src/Sidebar/Collapsible.js
@@ -3,19 +3,25 @@ import PropTypes from 'prop-types';
 
 import { Details, Summary } from './styled';
 
-const propTypes = {
-  children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
-  title: PropTypes.string.isRequired,
-  open: PropTypes.bool.isRequired,
-};
-
-const Collapsible = ({ title, children, open }) => (
-  <Details open={open}>
-    <Summary>{title}</Summary>
-    {children}
-  </Details>
-);
-
-Collapsible.propTypes = propTypes;
-
-export default Collapsible;
+export default class Collapsible extends React.Component {
+  static propTypes = {
+    id: PropTypes.string.isRequired,
+    children: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
+      .isRequired,
+    title: PropTypes.string.isRequired,
+    open: PropTypes.bool.isRequired,
+    expanded: PropTypes.func.isRequired,
+  };
+  onClick = () => {
+    this.props.expanded(this.props.id, !this.props.open);
+  };
+  render() {
+    const { title, children, open } = this.props;
+    return (
+      <Details open={open} onClick={this.onClick}>
+        <Summary>{title}</Summary>
+        {children}
+      </Details>
+    );
+  }
+}

--- a/frontend/src/Sidebar/Collapsible.js
+++ b/frontend/src/Sidebar/Collapsible.js
@@ -28,7 +28,7 @@ export default class Collapsible extends React.Component {
   render() {
     const { title, children } = this.props;
     const { open } = this.state;
-    const rightArrow = String.fromCharCode(9654);
+    const rightArrow = String.fromCharCode(9658);
     const downArrow = String.fromCharCode(9660);
     return (
       <Details onClick={this.onClick}>

--- a/frontend/src/Sidebar/Collapsible.js
+++ b/frontend/src/Sidebar/Collapsible.js
@@ -9,11 +9,11 @@ export default class Collapsible extends React.Component {
     children: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
       .isRequired,
     title: PropTypes.string.isRequired,
+    // eslint-disable-next-line react/no-unused-prop-types
     open: PropTypes.bool.isRequired,
     expanded: PropTypes.func.isRequired,
   };
   static getDerivedStateFromProps(nextProps) {
-    console.log('@getDerivedStateFromProps open:', nextProps.open);
     return { open: nextProps.open };
   }
   state = {
@@ -28,11 +28,15 @@ export default class Collapsible extends React.Component {
   render() {
     const { title, children } = this.props;
     const { open } = this.state;
+    const rightArrow = String.fromCharCode(9654);
+    const downArrow = String.fromCharCode(9660);
     return (
-      <div style={{cursor: 'default', marginLeft: '1rem'}} onClick={this.onClick}>
-        <div>{title}</div>
+      <Details onClick={this.onClick}>
+        <Summary>
+          {open ? downArrow : rightArrow} {title}
+        </Summary>
         {open && children}
-      </div>
+      </Details>
     );
   }
 }

--- a/frontend/src/Sidebar/Collapsible.js
+++ b/frontend/src/Sidebar/Collapsible.js
@@ -31,8 +31,8 @@ export default class Collapsible extends React.Component {
     const rightArrow = String.fromCharCode(9658);
     const downArrow = String.fromCharCode(9660);
     return (
-      <Details onClick={this.onClick}>
-        <Summary>
+      <Details>
+        <Summary onClick={this.onClick}>
           {open ? downArrow : rightArrow} {title}
         </Summary>
         {open && children}

--- a/frontend/src/Sidebar/Collapsible.js
+++ b/frontend/src/Sidebar/Collapsible.js
@@ -12,16 +12,27 @@ export default class Collapsible extends React.Component {
     open: PropTypes.bool.isRequired,
     expanded: PropTypes.func.isRequired,
   };
-  onClick = () => {
-    this.props.expanded(this.props.id, !this.props.open);
+  static getDerivedStateFromProps(nextProps) {
+    console.log('@getDerivedStateFromProps open:', nextProps.open);
+    return { open: nextProps.open };
+  }
+  state = {
+    open: false,
+  };
+  onClick = e => {
+    e.stopPropagation();
+    const { open } = this.state;
+    this.props.expanded(this.props.id, !open);
+    this.setState({ open: !open });
   };
   render() {
-    const { title, children, open } = this.props;
+    const { title, children } = this.props;
+    const { open } = this.state;
     return (
-      <Details open={open} onClick={this.onClick}>
-        <Summary>{title}</Summary>
-        {children}
-      </Details>
+      <div style={{cursor: 'default', marginLeft: '1rem'}} onClick={this.onClick}>
+        <div>{title}</div>
+        {open && children}
+      </div>
     );
   }
 }

--- a/frontend/src/Sidebar/Collapsible.test.js
+++ b/frontend/src/Sidebar/Collapsible.test.js
@@ -1,95 +1,18 @@
 /* eslint-disable */
 import React from 'react';
-import { BrowserRouter, Link } from 'react-router-dom';
 import renderer from 'react-test-renderer';
 
 import Collapsible from './Collapsible';
 
-import { getTree, getChildren } from './utils';
 
-describe('creating tree', () => {
-  let tree;
-  const topics = [{ _id: '1', name: 'Voyage', order: 1 }];
-  const sub_topics = [
-    { _id: '1', parent: '0', name: 'About this wiki', order: 1 },
-    { _id: '2', parent: '0', name: 'About Voyages', order: 2 },
-  ];
-  const articles = [
-    {
-      _id: '1',
-      topic: topics[0],
-      sub_topic: sub_topics[0],
-      title: 'Home',
-      order: 1,
-    },
-    {
-      _id: '2',
-      topic: topics[0],
-      sub_topic: sub_topics[0],
-      title: 'How to Contribute',
-      order: 2,
-    },
-    {
-      _id: '3',
-      topic: topics[0],
-      sub_topic: sub_topics[1],
-      title: 'About Voyages',
-      order: 1,
-    },
-  ];
-  const expectedTree = {
-    Voyage: {
-      'About this wiki': { Home: '1', 'How to Contribute': '2' },
-      'About Voyages': { 'About Voyages': '3' },
-    },
-  };
-  const nop = () => {};
+it('should create elements', () => {
+  const d = renderer
+    .create(
+      <Collapsible id="" title="test title" open={false} expanded={() => {}} >
+        {{ _id: '1', title: 'Some article title' }}
+      </Collapsible>
+    )
+    .toJSON();
 
-  it('should create article tree', () => {
-    tree = getTree(articles);
-    expect(tree).toEqual(expectedTree);
-  });
-
-  it('should create elements', () => {
-    const path = ['Voyage', 'About this wiki', 'Home'];
-    const elements = getChildren(tree, path, nop);
-
-    // expect(elements).toEqual(expectedElements);
-
-    const d = renderer
-      .create(
-        <BrowserRouter>
-          <React.Fragment>{elements}</React.Fragment>
-        </BrowserRouter>
-      )
-      .toJSON();
-
-    expect(d).toMatchSnapshot();
-  });
+  expect(d).toMatchSnapshot();
 });
-
-// const expectedElements = (
-//   <BrowserRouter>
-//     <React.Fragment>
-//       <Collapsible key="Voyage" title="Voyage" open={true}>
-//         <Collapsible
-//           key="About this wiki"
-//           title="About this wiki"
-//           open={true}
-//         >
-//           <Link key="Home" to={'/cms/1'}>
-//             Home
-//           </Link>
-//           <Link key="How to Contribute" to={'/cms/2'}>
-//             How to Contribute
-//           </Link>
-//         </Collapsible>
-//         <Collapsible key="About Voyages" title="About Voyages" open={false}>
-//           <Link key="About Voyages" to={'/cms/3'}>
-//             About Voyages
-//           </Link>
-//         </Collapsible>
-//       </Collapsible>
-//     </React.Fragment>
-//   </BrowserRouter>
-// );

--- a/frontend/src/Sidebar/Collapsible.test.js
+++ b/frontend/src/Sidebar/Collapsible.test.js
@@ -43,6 +43,7 @@ describe('creating tree', () => {
       'About Voyages': { 'About Voyages': '3' },
     },
   };
+  const nop = () => {};
 
   it('should create article tree', () => {
     tree = getTree(articles);
@@ -51,7 +52,7 @@ describe('creating tree', () => {
 
   it('should create elements', () => {
     const path = ['Voyage', 'About this wiki', 'Home'];
-    const elements = getChildren(tree, path);
+    const elements = getChildren(tree, path, nop);
 
     // expect(elements).toEqual(expectedElements);
 

--- a/frontend/src/Sidebar/Collapsible.test.js
+++ b/frontend/src/Sidebar/Collapsible.test.js
@@ -24,7 +24,7 @@ it('should expand on click', () => {
       {{ _id: '1', title: 'Some article title' }}
     </Collapsible>
   );
-  comp.instance().onClick({ stopPropagation: () => {}});
+  comp.instance().onClick({ stopPropagation: () => {} });
   expect(comp).toMatchSnapshot();
   expect(expand).toHaveBeenCalled();
   expect(comp.instance().state.open).toBe(true);

--- a/frontend/src/Sidebar/Collapsible.test.js
+++ b/frontend/src/Sidebar/Collapsible.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
 
 import Collapsible from './Collapsible';
 
@@ -14,4 +15,17 @@ it('should create elements', () => {
     .toJSON();
 
   expect(d).toMatchSnapshot();
+});
+
+it('should expand on click', () => {
+  const expand = jest.fn();
+  const comp = shallow(
+    <Collapsible id="" title="test title" open={false} expanded={expand}>
+      {{ _id: '1', title: 'Some article title' }}
+    </Collapsible>
+  );
+  comp.instance().onClick({ stopPropagation: () => {}});
+  expect(comp).toMatchSnapshot();
+  expect(expand).toHaveBeenCalled();
+  expect(comp.instance().state.open).toBe(true);
 });

--- a/frontend/src/Sidebar/Collapsible.test.js
+++ b/frontend/src/Sidebar/Collapsible.test.js
@@ -4,11 +4,10 @@ import renderer from 'react-test-renderer';
 
 import Collapsible from './Collapsible';
 
-
 it('should create elements', () => {
   const d = renderer
     .create(
-      <Collapsible id="" title="test title" open={false} expanded={() => {}} >
+      <Collapsible id="" title="test title" open={false} expanded={() => {}}>
         {{ _id: '1', title: 'Some article title' }}
       </Collapsible>
     )

--- a/frontend/src/Sidebar/Sidebar.js
+++ b/frontend/src/Sidebar/Sidebar.js
@@ -16,11 +16,7 @@ const Sidebar = ({ articles, match, onArticleSelect }) => {
 Sidebar.propTypes = {
   articles: PropTypes.array.isRequired,
   match: PropTypes.object.isRequired,
-  onArticleSelect: PropTypes.func,
-};
-
-Sidebar.defaultProps = {
-  onArticleSelect: () => {},
+  onArticleSelect: PropTypes.func.isRequired,
 };
 
 export default Sidebar;

--- a/frontend/src/Sidebar/Sidebar.js
+++ b/frontend/src/Sidebar/Sidebar.js
@@ -1,67 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { getTree, getChildren } from './utils';
+import buildTree from './utils';
 
 import { Wrapper } from './styled';
 
-/* eslint-disable camelcase */
-export default class Sidebar extends React.Component {
-  static propTypes = {
-    articles: PropTypes.array.isRequired,
-    match: PropTypes.object.isRequired,
-    onArticleSelect: PropTypes.func,
-  };
+let articlesHtml = [];
 
-  static defaultProps = {
-    onArticleSelect: () => {},
-  };
+const Sidebar = ({ articles, match, onArticleSelect }) => {
+  if (articlesHtml.length === 0) {
+    articlesHtml = buildTree(articles, match.params.id, onArticleSelect);
+  }
+  return <Wrapper>{articlesHtml}</Wrapper>;
+};
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      articlesHtml: [],
-    };
-  }
+Sidebar.propTypes = {
+  articles: PropTypes.array.isRequired,
+  match: PropTypes.object.isRequired,
+  onArticleSelect: PropTypes.func,
+};
 
-  componentDidMount() {
-    this.buildTree(this.props.articles, this.props.match.params.id);
-  }
+Sidebar.defaultProps = {
+  onArticleSelect: () => {},
+};
 
-  componentWillReceiveProps(nextProps) {
-    const { articles } = nextProps;
-    this.buildTree(articles, nextProps.match.params.id);
-  }
-  buildTree(articles, id) {
-    let selectedArticlePath = [];
-    const { onArticleSelect } = this.props;
-    // only build the sidebar tree once on startup, otherwise the tree is
-    // collapsed everytime an article is selected/viewed
-    if (this.state.articlesHtml.length === 0) {
-      if (id) {
-        const selectedArticles = articles.filter(article => article._id === id);
-        if (selectedArticles.length) {
-          const { topic, sub_topic, title } = selectedArticles[0];
-          selectedArticlePath = [topic.name, title];
-          // eslint-disable-next-line camelcase
-          if (sub_topic) {
-            selectedArticlePath = selectedArticlePath.concat(
-              sub_topic.name.split('>')
-            );
-          }
-        }
-      }
-      const tree = getTree(articles);
-      const articlesHtml = getChildren(
-        tree,
-        selectedArticlePath,
-        onArticleSelect
-      );
-      this.setState({ articlesHtml });
-    }
-  }
-
-  render() {
-    return <Wrapper>{this.state.articlesHtml}</Wrapper>;
-  }
-}
-/* eslint-enable camelcase */
+export default Sidebar;

--- a/frontend/src/Sidebar/Sidebar.js
+++ b/frontend/src/Sidebar/Sidebar.js
@@ -130,11 +130,11 @@ export default class Sidebar extends React.Component {
             <MenuIcon />
           </IconButton>
         )}
-        {/* eslint-disable prettier/prettier */
-          mobile
-            ? this.renderDrawer(articlesHtml, open)
-            : <Wrapper>{articlesHtml}</Wrapper>
-        }
+        {mobile ? (
+          this.renderDrawer(articlesHtml, open)
+        ) : (
+          <Wrapper>{articlesHtml}</Wrapper>
+        )}
       </div>
     );
   }

--- a/frontend/src/Sidebar/Sidebar.js
+++ b/frontend/src/Sidebar/Sidebar.js
@@ -1,22 +1,130 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import buildTree from './utils';
+
+// Material UI components
+import Drawer from 'material-ui/Drawer';
+import IconButton from 'material-ui/IconButton';
+import MenuIcon from '@material-ui/icons/Menu';
+
+import expandTree from './expandTree';
+import buildHtml, { getTree } from './utils';
 
 import { Wrapper } from './styled';
 
-let articlesHtml = [];
+const BREAK_MOBILE = 900;
 
-const Sidebar = ({ articles, match, onArticleSelect }) => {
-  if (articlesHtml.length === 0) {
-    articlesHtml = buildTree(articles, match.params.id, onArticleSelect);
+export default class Sidebar extends React.Component {
+  static propTypes = {
+    /* eslint-disable react/no-unused-prop-types */
+    articles: PropTypes.array.isRequired,
+    match: PropTypes.object.isRequired,
+    /* eslint-enable react/no-unused-prop-types */
+  };
+
+  state = {
+    open: false,
+    articlesHtml: [],
+    mobile: false,
+  };
+
+  componentDidMount() {
+    const mobile = this.checkMobile();
+    // eslint-disable-next-line react/no-did-mount-set-state
+    this.setState({ mobile });
+    window.addEventListener('resize', this.handleResize);
   }
-  return <Wrapper>{articlesHtml}</Wrapper>;
-};
 
-Sidebar.propTypes = {
-  articles: PropTypes.array.isRequired,
-  match: PropTypes.object.isRequired,
-  onArticleSelect: PropTypes.func.isRequired,
-};
+  componentWillReceiveProps(nextProps) {
+    if (this.state.articlesHtml.length === 0 && nextProps.articles.length) {
+      const { articles } = nextProps;
+      const articleTree = getTree(articles);
+      const { match } = this.props;
+      const { mobile } = this.state;
+      const selFn = mobile ? this.closeDrawer : this.nop;
+      const articlesHtml = buildHtml(
+        articles,
+        articleTree,
+        match.params.id,
+        selFn,
+        this.onExpanded
+      );
+      this.setState({ articleTree, articlesHtml });
+    }
+  }
 
-export default Sidebar;
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  onExpanded = (_id, expanded) => {
+    console.log('@onExpanded for _id, expanded:', _id, expanded);
+    const articleTree = expandTree(this.state.articleTree, _id, expanded);
+    this.setState({ articleTree });
+  };
+
+  nop = () => {};
+
+  handleResize = () => {
+    const mobile = this.checkMobile();
+    this.setState({ mobile });
+  };
+
+  checkMobile = () => {
+    let { mobile } = this.state;
+    const windowWidth = window.innerWidth;
+
+    if (mobile && windowWidth > BREAK_MOBILE) {
+      mobile = false;
+    } else if (!mobile && windowWidth <= BREAK_MOBILE) {
+      mobile = true;
+    }
+    return mobile;
+  };
+
+  openDrawer = () => {
+    this.setState(() => ({
+      open: true,
+    }));
+  };
+
+  closeDrawer = () => {
+    this.setState(() => ({
+      open: false,
+    }));
+  };
+
+  renderDrawer = (component, open) => (
+    <Drawer open={open} onClose={this.closeDrawer}>
+      <div
+        style={{ width: 250 }}
+        tabIndex={0}
+        role="button"
+        onClick={this.closeDrawer}
+        onKeyDown={this.closeDrawer}
+      />
+      {component}
+    </Drawer>
+  );
+
+  render() {
+    const { articlesHtml, mobile, open } = this.state;
+    return (
+      <div>
+        {mobile && (
+          <IconButton
+            colors="inherit"
+            aria-label="Menu"
+            onClick={this.openDrawer}
+          >
+            <MenuIcon />
+          </IconButton>
+        )}
+        {/* eslint-disable prettier/prettier */
+          mobile
+            ? this.renderDrawer(articlesHtml, open)
+            : <Wrapper>{articlesHtml}</Wrapper>
+        }
+      </div>
+    );
+  }
+}

--- a/frontend/src/Sidebar/Sidebar.js
+++ b/frontend/src/Sidebar/Sidebar.js
@@ -7,11 +7,9 @@ import IconButton from 'material-ui/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 
 import expandTree from './expandTree';
-import buildHtml, { getTree } from './utils';
+import buildHtml, { getTree, checkMobile } from './utils';
 
 import { Wrapper } from './styled';
-
-const BREAK_MOBILE = 900;
 
 export default class Sidebar extends React.Component {
   static propTypes = {
@@ -28,7 +26,7 @@ export default class Sidebar extends React.Component {
   };
 
   componentDidMount() {
-    const mobile = this.checkMobile();
+    const mobile = checkMobile(false, window.innerWidth);
     // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({ mobile });
     window.addEventListener('resize', this.handleResize);
@@ -66,20 +64,8 @@ export default class Sidebar extends React.Component {
   };
 
   handleResize = () => {
-    const mobile = this.checkMobile();
+    const mobile = checkMobile(this.state.mobile, window.innerWidth);
     this.setState({ mobile });
-  };
-
-  checkMobile = () => {
-    let { mobile } = this.state;
-    const windowWidth = window.innerWidth;
-
-    if (mobile && windowWidth > BREAK_MOBILE) {
-      mobile = false;
-    } else if (!mobile && windowWidth <= BREAK_MOBILE) {
-      mobile = true;
-    }
-    return mobile;
   };
 
   openDrawer = () => {

--- a/frontend/src/Sidebar/Sidebar.js
+++ b/frontend/src/Sidebar/Sidebar.js
@@ -58,7 +58,6 @@ export default class Sidebar extends React.Component {
 
   onExpanded = (_id, expanded) => {
     const articleTree = expandTree(this.state.articleTree, _id, expanded);
-    console.log('@onExpanded:', articleTree);
     this.setState({ articleTree });
   };
 
@@ -108,7 +107,7 @@ export default class Sidebar extends React.Component {
   renderDrawer = (component, open) => (
     <Drawer open={open} onClose={this.closeDrawer}>
       <div
-        style={{ width: 250 }}
+        style={{ paddingTop: '1rem', width: 250 }}
         tabIndex={0}
         role="button"
         onClick={this.closeDrawer}

--- a/frontend/src/Sidebar/Sidebar.js
+++ b/frontend/src/Sidebar/Sidebar.js
@@ -9,6 +9,11 @@ export default class Sidebar extends React.Component {
   static propTypes = {
     articles: PropTypes.array.isRequired,
     match: PropTypes.object.isRequired,
+    onArticleSelect: PropTypes.func,
+  };
+
+  static defaultProps = {
+    onArticleSelect: () => {},
   };
 
   constructor(props) {
@@ -28,6 +33,7 @@ export default class Sidebar extends React.Component {
   }
   buildTree(articles, id) {
     let selectedArticlePath = [];
+    const { onArticleSelect } = this.props;
     // only build the sidebar tree once on startup, otherwise the tree is
     // collapsed everytime an article is selected/viewed
     if (this.state.articlesHtml.length === 0) {
@@ -45,7 +51,11 @@ export default class Sidebar extends React.Component {
         }
       }
       const tree = getTree(articles);
-      const articlesHtml = getChildren(tree, selectedArticlePath);
+      const articlesHtml = getChildren(
+        tree,
+        selectedArticlePath,
+        onArticleSelect
+      );
       this.setState({ articlesHtml });
     }
   }

--- a/frontend/src/Sidebar/Sidebar.js
+++ b/frontend/src/Sidebar/Sidebar.js
@@ -18,14 +18,20 @@ export default class Sidebar extends React.Component {
     };
   }
 
+  componentDidMount() {
+    this.buildTree(this.props.articles, this.props.match.params.id);
+  }
+
   componentWillReceiveProps(nextProps) {
     const { articles } = nextProps;
+    this.buildTree(articles, nextProps.match.params.id);
+  }
+  buildTree(articles, id) {
     let selectedArticlePath = [];
     // only build the sidebar tree once on startup, otherwise the tree is
     // collapsed everytime an article is selected/viewed
     if (this.state.articlesHtml.length === 0) {
-      if (nextProps.match.params.id) {
-        const { id } = nextProps.match.params;
+      if (id) {
         const selectedArticles = articles.filter(article => article._id === id);
         if (selectedArticles.length) {
           const { topic, sub_topic, title } = selectedArticles[0];

--- a/frontend/src/Sidebar/Sidebar.js
+++ b/frontend/src/Sidebar/Sidebar.js
@@ -57,12 +57,14 @@ export default class Sidebar extends React.Component {
   }
 
   onExpanded = (_id, expanded) => {
-    console.log('@onExpanded for _id, expanded:', _id, expanded);
     const articleTree = expandTree(this.state.articleTree, _id, expanded);
+    console.log('@onExpanded:', articleTree);
     this.setState({ articleTree });
   };
 
-  nop = () => {};
+  nop = e => {
+    e.stopPropagation();
+  };
 
   handleResize = () => {
     const mobile = this.checkMobile();
@@ -82,7 +84,17 @@ export default class Sidebar extends React.Component {
   };
 
   openDrawer = () => {
+    const { articles, match } = this.props;
+    const { articleTree } = this.state;
+    const articlesHtml = buildHtml(
+      articles,
+      articleTree,
+      match.params.id,
+      this.closeDrawer,
+      this.onExpanded
+    );
     this.setState(() => ({
+      articlesHtml,
       open: true,
     }));
   };

--- a/frontend/src/Sidebar/Sidebar.test.js
+++ b/frontend/src/Sidebar/Sidebar.test.js
@@ -83,17 +83,16 @@ const match = {
   params: { id: '' },
 };
 
-function flushPromises() {
-  return new Promise(resolve => setImmediate(resolve));
-}
-
 let comp;
 let inst;
 
-it('should initialise Sidebar correctly', () => {
+beforeEach(() => {
   comp = shallow(<Sidebar articles={articles} match={match} />);
-  inst = comp.instance();
   comp.setProps({ articles });
+  inst = comp.instance();
+});
+
+it('should initialise Sidebar correctly', () => {
   expect(inst.state.open).toBe(false);
   expect(inst.state.articleTree).toEqual(expectedTree);
   expect(inst.state.articlesHtml).toMatchSnapshot();
@@ -118,17 +117,6 @@ it('should close mobile drawer', () => {
 it('should expand tree', () => {
   inst.onExpanded('1', true);
   expect(inst.state.articleTree).toEqual(expectedExpandedTree);
-});
-
-it('should check mobile', () => {
-  const mobile = inst.checkMobile();
-  expect(mobile).toBe(false);
-});
-
-it('should set mobile if innerWidth < 900', () => {
-  window.innerWidth = 400;
-  const mobile = inst.checkMobile();
-  expect(mobile).toBe(true);
 });
 
 it('should remove resize event listener', () => {

--- a/frontend/src/Sidebar/Sidebar.test.js
+++ b/frontend/src/Sidebar/Sidebar.test.js
@@ -1,0 +1,142 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Sidebar from './Sidebar';
+
+const topics = [{ _id: '1', name: 'Voyage', order: 1 }];
+// eslint-disable-next-line camelcase
+const sub_topics = [
+  { _id: '10', parent: '1', name: 'About this Wiki', order: 1 },
+  { _id: '11', parent: '1', name: 'About Voyages', order: 2 },
+];
+
+const articles = [
+  {
+    _id: '100',
+    topic: topics[0],
+    sub_topic: sub_topics[0],
+    title: 'Home',
+    order: 1,
+  },
+  {
+    _id: '101',
+    topic: topics[0],
+    sub_topic: sub_topics[0],
+    title: 'How to Contribute',
+    order: 2,
+  },
+  {
+    _id: '102',
+    topic: topics[0],
+    sub_topic: sub_topics[1],
+    title: 'Voyage Roadmap',
+    order: 1,
+  },
+  {
+    _id: '103',
+    topic: topics[0],
+    sub_topic: null,
+    title: 'Introduction',
+    order: 1,
+  },
+];
+
+const expectedTree = {
+  Voyage: {
+    _id: '1',
+    expanded: false,
+    'About this Wiki': {
+      _id: '10',
+      expanded: false,
+      Home: '100',
+      'How to Contribute': '101',
+    },
+    'About Voyages': {
+      _id: '11',
+      expanded: false,
+      'Voyage Roadmap': '102',
+    },
+    Introduction: '103',
+  },
+};
+
+const expectedExpandedTree = {
+  Voyage: {
+    _id: '1',
+    expanded: true,
+    'About this Wiki': {
+      _id: '10',
+      expanded: false,
+      Home: '100',
+      'How to Contribute': '101',
+    },
+    'About Voyages': {
+      _id: '11',
+      expanded: false,
+      'Voyage Roadmap': '102',
+    },
+    Introduction: '103',
+  },
+};
+
+const match = {
+  params: { id: '' },
+};
+
+function flushPromises() {
+  return new Promise(resolve => setImmediate(resolve));
+}
+
+let comp;
+let inst;
+
+it('should initialise Sidebar correctly', () => {
+  comp = shallow(<Sidebar articles={articles} match={match} />);
+  inst = comp.instance();
+  comp.setProps({ articles });
+  expect(inst.state.open).toBe(false);
+  expect(inst.state.articleTree).toEqual(expectedTree);
+  expect(inst.state.articlesHtml).toMatchSnapshot();
+});
+
+it('should show mobile drawer', () => {
+  expect.hasAssertions();
+  comp.setState({ articlesHtml: null, mobile: true });
+  inst.openDrawer();
+  return Promise.resolve().then(() => {
+    comp.update();
+    expect(inst.state.open).toBe(true);
+    expect(comp).toMatchSnapshot();
+  });
+});
+
+it('should close mobile drawer', () => {
+  inst.closeDrawer();
+  expect(inst.state.open).toBe(false);
+});
+
+it('should expand tree', () => {
+  inst.onExpanded('1', true);
+  expect(inst.state.articleTree).toEqual(expectedExpandedTree);
+});
+
+it('should check mobile', () => {
+  const mobile = inst.checkMobile();
+  expect(mobile).toBe(false);
+});
+
+it('should set mobile if innerWidth < 900', () => {
+  window.innerWidth = 400;
+  const mobile = inst.checkMobile();
+  expect(mobile).toBe(true);
+});
+
+it('should remove resize event listener', () => {
+  const remover = jest
+    .spyOn(global, 'removeEventListener')
+    .mockImplementation(() => {});
+  return Promise.resolve().then(() => {
+    comp.unmount();
+    expect(remover).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/Sidebar/__snapshots__/Collapsible.test.js.snap
+++ b/frontend/src/Sidebar/__snapshots__/Collapsible.test.js.snap
@@ -1,64 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`creating tree should create elements 1`] = `
-<details
+exports[`should create elements 1`] = `
+<div
   className="sc-bdVaJa bLWtbN"
-  open={true}
+  onClick={[Function]}
 >
-  <summary
-    className="sc-bwzfXH jvlMsP"
+  <div
+    className="sc-bwzfXH bpFyCA"
   >
-    Voyage
-  </summary>
-  <details
-    className="sc-bdVaJa bLWtbN"
-    open={true}
-  >
-    <summary
-      className="sc-bwzfXH jvlMsP"
-    >
-      About this wiki
-    </summary>
-    <li
-      className="sc-bxivhb iXnkAE"
-    >
-      <a
-        href="/cms/1"
-        onClick={[Function]}
-      >
-        Home
-      </a>
-    </li>
-    <li
-      className="sc-bxivhb iXnkAE"
-    >
-      <a
-        href="/cms/2"
-        onClick={[Function]}
-      >
-        How to Contribute
-      </a>
-    </li>
-  </details>
-  <details
-    className="sc-bdVaJa bLWtbN"
-    open={false}
-  >
-    <summary
-      className="sc-bwzfXH jvlMsP"
-    >
-      About Voyages
-    </summary>
-    <li
-      className="sc-bxivhb iXnkAE"
-    >
-      <a
-        href="/cms/3"
-        onClick={[Function]}
-      >
-        About Voyages
-      </a>
-    </li>
-  </details>
-</details>
+    ▶
+     
+    test title
+  </div>
+</div>
 `;

--- a/frontend/src/Sidebar/__snapshots__/Collapsible.test.js.snap
+++ b/frontend/src/Sidebar/__snapshots__/Collapsible.test.js.snap
@@ -8,7 +8,7 @@ exports[`should create elements 1`] = `
   <div
     className="sc-bwzfXH bpFyCA"
   >
-    ▶
+    ►
      
     test title
   </div>

--- a/frontend/src/Sidebar/__snapshots__/Collapsible.test.js.snap
+++ b/frontend/src/Sidebar/__snapshots__/Collapsible.test.js.snap
@@ -14,3 +14,117 @@ exports[`should create elements 1`] = `
   </div>
 </div>
 `;
+
+exports[`should expand on click 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <Collapsible
+    expanded={[Function]}
+    id=""
+    open={false}
+    title="test title"
+>
+    Object {
+        "_id": "1",
+        "title": "Some article title",
+      }
+</Collapsible>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "class",
+    "props": Object {
+      "children": Array [
+        <styled.div>
+          ►
+           
+          test title
+</styled.div>,
+        false,
+      ],
+      "onClick": [Function],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "children": Array [
+            "►",
+            " ",
+            "test title",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          "►",
+          " ",
+          "test title",
+        ],
+        "type": [Function],
+      },
+      false,
+    ],
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {
+        "children": Array [
+          <styled.div>
+            ►
+             
+            test title
+</styled.div>,
+          false,
+        ],
+        "onClick": [Function],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "children": Array [
+              "►",
+              " ",
+              "test title",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "►",
+            " ",
+            "test title",
+          ],
+          "type": [Function],
+        },
+        false,
+      ],
+      "type": [Function],
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;

--- a/frontend/src/Sidebar/__snapshots__/Collapsible.test.js.snap
+++ b/frontend/src/Sidebar/__snapshots__/Collapsible.test.js.snap
@@ -3,10 +3,10 @@
 exports[`should create elements 1`] = `
 <div
   className="sc-bdVaJa bLWtbN"
-  onClick={[Function]}
 >
   <div
     className="sc-bwzfXH bpFyCA"
+    onClick={[Function]}
   >
     ►
      
@@ -43,14 +43,15 @@ ShallowWrapper {
     "nodeType": "class",
     "props": Object {
       "children": Array [
-        <styled.div>
+        <styled.div
+          onClick={[Function]}
+>
           ►
            
           test title
 </styled.div>,
         false,
       ],
-      "onClick": [Function],
     },
     "ref": null,
     "rendered": Array [
@@ -64,6 +65,7 @@ ShallowWrapper {
             " ",
             "test title",
           ],
+          "onClick": [Function],
         },
         "ref": null,
         "rendered": Array [
@@ -84,14 +86,15 @@ ShallowWrapper {
       "nodeType": "class",
       "props": Object {
         "children": Array [
-          <styled.div>
+          <styled.div
+            onClick={[Function]}
+>
             ►
              
             test title
 </styled.div>,
           false,
         ],
-        "onClick": [Function],
       },
       "ref": null,
       "rendered": Array [
@@ -105,6 +108,7 @@ ShallowWrapper {
               " ",
               "test title",
             ],
+            "onClick": [Function],
           },
           "ref": null,
           "rendered": Array [

--- a/frontend/src/Sidebar/__snapshots__/Sidebar.test.js.snap
+++ b/frontend/src/Sidebar/__snapshots__/Sidebar.test.js.snap
@@ -361,7 +361,7 @@ ShallowWrapper {
           },
           Object {
             "instance": null,
-            "key": "13",
+            "key": "20",
             "nodeType": "class",
             "props": Object {
               "children": Array [
@@ -425,7 +425,7 @@ ShallowWrapper {
             "rendered": Array [
               Object {
                 "instance": null,
-                "key": "9",
+                "key": "16",
                 "nodeType": "class",
                 "props": Object {
                   "children": Array [
@@ -457,7 +457,7 @@ ShallowWrapper {
                 "rendered": Array [
                   Object {
                     "instance": null,
-                    "key": "7",
+                    "key": "14",
                     "nodeType": "class",
                     "props": Object {
                       "children": <Styled(NavLink)
@@ -484,7 +484,7 @@ ShallowWrapper {
                   },
                   Object {
                     "instance": null,
-                    "key": "8",
+                    "key": "15",
                     "nodeType": "class",
                     "props": Object {
                       "children": <Styled(NavLink)
@@ -514,7 +514,7 @@ ShallowWrapper {
               },
               Object {
                 "instance": null,
-                "key": "11",
+                "key": "18",
                 "nodeType": "class",
                 "props": Object {
                   "children": Array [
@@ -537,7 +537,7 @@ ShallowWrapper {
                 "rendered": Array [
                   Object {
                     "instance": null,
-                    "key": "10",
+                    "key": "17",
                     "nodeType": "class",
                     "props": Object {
                       "children": <Styled(NavLink)
@@ -567,7 +567,7 @@ ShallowWrapper {
               },
               Object {
                 "instance": null,
-                "key": "12",
+                "key": "19",
                 "nodeType": "class",
                 "props": Object {
                   "children": <Styled(NavLink)
@@ -818,7 +818,7 @@ ShallowWrapper {
             },
             Object {
               "instance": null,
-              "key": "13",
+              "key": "20",
               "nodeType": "class",
               "props": Object {
                 "children": Array [
@@ -882,7 +882,7 @@ ShallowWrapper {
               "rendered": Array [
                 Object {
                   "instance": null,
-                  "key": "9",
+                  "key": "16",
                   "nodeType": "class",
                   "props": Object {
                     "children": Array [
@@ -914,7 +914,7 @@ ShallowWrapper {
                   "rendered": Array [
                     Object {
                       "instance": null,
-                      "key": "7",
+                      "key": "14",
                       "nodeType": "class",
                       "props": Object {
                         "children": <Styled(NavLink)
@@ -941,7 +941,7 @@ ShallowWrapper {
                     },
                     Object {
                       "instance": null,
-                      "key": "8",
+                      "key": "15",
                       "nodeType": "class",
                       "props": Object {
                         "children": <Styled(NavLink)
@@ -971,7 +971,7 @@ ShallowWrapper {
                 },
                 Object {
                   "instance": null,
-                  "key": "11",
+                  "key": "18",
                   "nodeType": "class",
                   "props": Object {
                     "children": Array [
@@ -994,7 +994,7 @@ ShallowWrapper {
                   "rendered": Array [
                     Object {
                       "instance": null,
-                      "key": "10",
+                      "key": "17",
                       "nodeType": "class",
                       "props": Object {
                         "children": <Styled(NavLink)
@@ -1024,7 +1024,7 @@ ShallowWrapper {
                 },
                 Object {
                   "instance": null,
-                  "key": "12",
+                  "key": "19",
                   "nodeType": "class",
                   "props": Object {
                     "children": <Styled(NavLink)

--- a/frontend/src/Sidebar/__snapshots__/Sidebar.test.js.snap
+++ b/frontend/src/Sidebar/__snapshots__/Sidebar.test.js.snap
@@ -1,0 +1,1070 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should initialise Sidebar correctly 1`] = `
+Array [
+  <Collapsible
+    expanded={[Function]}
+    id="1"
+    open={false}
+    title="Voyage"
+>
+    <Collapsible
+        expanded={[Function]}
+        id="10"
+        open={false}
+        title="About this Wiki"
+    >
+        <styled.li
+            onClick={[Function]}
+        >
+            <Styled(NavLink)
+                to="/cms/100"
+            >
+                Home
+            </Styled(NavLink)>
+        </styled.li>
+        <styled.li
+            onClick={[Function]}
+        >
+            <Styled(NavLink)
+                to="/cms/101"
+            >
+                How to Contribute
+            </Styled(NavLink)>
+        </styled.li>
+    </Collapsible>
+    <Collapsible
+        expanded={[Function]}
+        id="11"
+        open={false}
+        title="About Voyages"
+    >
+        <styled.li
+            onClick={[Function]}
+        >
+            <Styled(NavLink)
+                to="/cms/102"
+            >
+                Voyage Roadmap
+            </Styled(NavLink)>
+        </styled.li>
+    </Collapsible>
+    <styled.li
+        onClick={[Function]}
+    >
+        <Styled(NavLink)
+            to="/cms/103"
+        >
+            Introduction
+        </Styled(NavLink)>
+    </styled.li>
+</Collapsible>,
+]
+`;
+
+exports[`should show mobile drawer 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <Sidebar
+    articles={
+        Array [
+            Object {
+              "_id": "100",
+              "order": 1,
+              "sub_topic": Object {
+                "_id": "10",
+                "name": "About this Wiki",
+                "order": 1,
+                "parent": "1",
+              },
+              "title": "Home",
+              "topic": Object {
+                "_id": "1",
+                "name": "Voyage",
+                "order": 1,
+              },
+            },
+            Object {
+              "_id": "101",
+              "order": 2,
+              "sub_topic": Object {
+                "_id": "10",
+                "name": "About this Wiki",
+                "order": 1,
+                "parent": "1",
+              },
+              "title": "How to Contribute",
+              "topic": Object {
+                "_id": "1",
+                "name": "Voyage",
+                "order": 1,
+              },
+            },
+            Object {
+              "_id": "102",
+              "order": 1,
+              "sub_topic": Object {
+                "_id": "11",
+                "name": "About Voyages",
+                "order": 2,
+                "parent": "1",
+              },
+              "title": "Voyage Roadmap",
+              "topic": Object {
+                "_id": "1",
+                "name": "Voyage",
+                "order": 1,
+              },
+            },
+            Object {
+              "_id": "103",
+              "order": 1,
+              "sub_topic": null,
+              "title": "Introduction",
+              "topic": Object {
+                "_id": "1",
+                "name": "Voyage",
+                "order": 1,
+              },
+            },
+          ]
+    }
+    match={
+        Object {
+            "params": Object {
+              "id": "",
+            },
+          }
+    }
+/>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <WithStyles(IconButton)
+          aria-label="Menu"
+          colors="inherit"
+          onClick={[Function]}
+>
+          <pure(Menu) />
+</WithStyles(IconButton)>,
+        <WithStyles(Drawer)
+          onClose={[Function]}
+          open={true}
+>
+          <div
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="button"
+                    style={
+                              Object {
+                                        "paddingTop": "1rem",
+                                        "width": 250,
+                                      }
+                    }
+                    tabIndex={0}
+          />
+          <Collapsible
+                    expanded={[Function]}
+                    id="1"
+                    open={false}
+                    title="Voyage"
+          >
+                    <Collapsible
+                              expanded={[Function]}
+                              id="10"
+                              open={false}
+                              title="About this Wiki"
+                    >
+                              <styled.li
+                                        onClick={[Function]}
+                              >
+                                        <Styled(NavLink)
+                                                  to="/cms/100"
+                                        >
+                                                  Home
+                                        </Styled(NavLink)>
+                              </styled.li>
+                              <styled.li
+                                        onClick={[Function]}
+                              >
+                                        <Styled(NavLink)
+                                                  to="/cms/101"
+                                        >
+                                                  How to Contribute
+                                        </Styled(NavLink)>
+                              </styled.li>
+                    </Collapsible>
+                    <Collapsible
+                              expanded={[Function]}
+                              id="11"
+                              open={false}
+                              title="About Voyages"
+                    >
+                              <styled.li
+                                        onClick={[Function]}
+                              >
+                                        <Styled(NavLink)
+                                                  to="/cms/102"
+                                        >
+                                                  Voyage Roadmap
+                                        </Styled(NavLink)>
+                              </styled.li>
+                    </Collapsible>
+                    <styled.li
+                              onClick={[Function]}
+                    >
+                              <Styled(NavLink)
+                                        to="/cms/103"
+                              >
+                                        Introduction
+                              </Styled(NavLink)>
+                    </styled.li>
+          </Collapsible>
+</WithStyles(Drawer)>,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "aria-label": "Menu",
+          "children": <pure(Menu) />,
+          "colors": "inherit",
+          "onClick": [Function],
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {},
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "children": Array [
+            <div
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              style={
+                            Object {
+                                          "paddingTop": "1rem",
+                                          "width": 250,
+                                        }
+              }
+              tabIndex={0}
+/>,
+            Array [
+              <Collapsible
+                expanded={[Function]}
+                id="1"
+                open={false}
+                title="Voyage"
+>
+                <Collapsible
+                                expanded={[Function]}
+                                id="10"
+                                open={false}
+                                title="About this Wiki"
+                >
+                                <styled.li
+                                                onClick={[Function]}
+                                >
+                                                <Styled(NavLink)
+                                                                to="/cms/100"
+                                                >
+                                                                Home
+                                                </Styled(NavLink)>
+                                </styled.li>
+                                <styled.li
+                                                onClick={[Function]}
+                                >
+                                                <Styled(NavLink)
+                                                                to="/cms/101"
+                                                >
+                                                                How to Contribute
+                                                </Styled(NavLink)>
+                                </styled.li>
+                </Collapsible>
+                <Collapsible
+                                expanded={[Function]}
+                                id="11"
+                                open={false}
+                                title="About Voyages"
+                >
+                                <styled.li
+                                                onClick={[Function]}
+                                >
+                                                <Styled(NavLink)
+                                                                to="/cms/102"
+                                                >
+                                                                Voyage Roadmap
+                                                </Styled(NavLink)>
+                                </styled.li>
+                </Collapsible>
+                <styled.li
+                                onClick={[Function]}
+                >
+                                <Styled(NavLink)
+                                                to="/cms/103"
+                                >
+                                                Introduction
+                                </Styled(NavLink)>
+                </styled.li>
+</Collapsible>,
+            ],
+          ],
+          "onClose": [Function],
+          "open": true,
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "onClick": [Function],
+              "onKeyDown": [Function],
+              "role": "button",
+              "style": Object {
+                "paddingTop": "1rem",
+                "width": 250,
+              },
+              "tabIndex": 0,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": "div",
+          },
+          Object {
+            "instance": null,
+            "key": "13",
+            "nodeType": "class",
+            "props": Object {
+              "children": Array [
+                <Collapsible
+                  expanded={[Function]}
+                  id="10"
+                  open={false}
+                  title="About this Wiki"
+>
+                  <styled.li
+                                    onClick={[Function]}
+                  >
+                                    <Styled(NavLink)
+                                                      to="/cms/100"
+                                    >
+                                                      Home
+                                    </Styled(NavLink)>
+                  </styled.li>
+                  <styled.li
+                                    onClick={[Function]}
+                  >
+                                    <Styled(NavLink)
+                                                      to="/cms/101"
+                                    >
+                                                      How to Contribute
+                                    </Styled(NavLink)>
+                  </styled.li>
+</Collapsible>,
+                <Collapsible
+                  expanded={[Function]}
+                  id="11"
+                  open={false}
+                  title="About Voyages"
+>
+                  <styled.li
+                                    onClick={[Function]}
+                  >
+                                    <Styled(NavLink)
+                                                      to="/cms/102"
+                                    >
+                                                      Voyage Roadmap
+                                    </Styled(NavLink)>
+                  </styled.li>
+</Collapsible>,
+                <styled.li
+                  onClick={[Function]}
+>
+                  <Styled(NavLink)
+                                    to="/cms/103"
+                  >
+                                    Introduction
+                  </Styled(NavLink)>
+</styled.li>,
+              ],
+              "expanded": [Function],
+              "id": "1",
+              "open": false,
+              "title": "Voyage",
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": "9",
+                "nodeType": "class",
+                "props": Object {
+                  "children": Array [
+                    <styled.li
+                      onClick={[Function]}
+>
+                      <Styled(NavLink)
+                                            to="/cms/100"
+                      >
+                                            Home
+                      </Styled(NavLink)>
+</styled.li>,
+                    <styled.li
+                      onClick={[Function]}
+>
+                      <Styled(NavLink)
+                                            to="/cms/101"
+                      >
+                                            How to Contribute
+                      </Styled(NavLink)>
+</styled.li>,
+                  ],
+                  "expanded": [Function],
+                  "id": "10",
+                  "open": false,
+                  "title": "About this Wiki",
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": "7",
+                    "nodeType": "class",
+                    "props": Object {
+                      "children": <Styled(NavLink)
+                        to="/cms/100"
+>
+                        Home
+</Styled(NavLink)>,
+                      "onClick": [Function],
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "children": "Home",
+                        "to": "/cms/100",
+                      },
+                      "ref": null,
+                      "rendered": "Home",
+                      "type": [Function],
+                    },
+                    "type": [Function],
+                  },
+                  Object {
+                    "instance": null,
+                    "key": "8",
+                    "nodeType": "class",
+                    "props": Object {
+                      "children": <Styled(NavLink)
+                        to="/cms/101"
+>
+                        How to Contribute
+</Styled(NavLink)>,
+                      "onClick": [Function],
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "children": "How to Contribute",
+                        "to": "/cms/101",
+                      },
+                      "ref": null,
+                      "rendered": "How to Contribute",
+                      "type": [Function],
+                    },
+                    "type": [Function],
+                  },
+                ],
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "11",
+                "nodeType": "class",
+                "props": Object {
+                  "children": Array [
+                    <styled.li
+                      onClick={[Function]}
+>
+                      <Styled(NavLink)
+                                            to="/cms/102"
+                      >
+                                            Voyage Roadmap
+                      </Styled(NavLink)>
+</styled.li>,
+                  ],
+                  "expanded": [Function],
+                  "id": "11",
+                  "open": false,
+                  "title": "About Voyages",
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": "10",
+                    "nodeType": "class",
+                    "props": Object {
+                      "children": <Styled(NavLink)
+                        to="/cms/102"
+>
+                        Voyage Roadmap
+</Styled(NavLink)>,
+                      "onClick": [Function],
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "children": "Voyage Roadmap",
+                        "to": "/cms/102",
+                      },
+                      "ref": null,
+                      "rendered": "Voyage Roadmap",
+                      "type": [Function],
+                    },
+                    "type": [Function],
+                  },
+                ],
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "12",
+                "nodeType": "class",
+                "props": Object {
+                  "children": <Styled(NavLink)
+                    to="/cms/103"
+>
+                    Introduction
+</Styled(NavLink)>,
+                  "onClick": [Function],
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "class",
+                  "props": Object {
+                    "children": "Introduction",
+                    "to": "/cms/103",
+                  },
+                  "ref": null,
+                  "rendered": "Introduction",
+                  "type": [Function],
+                },
+                "type": [Function],
+              },
+            ],
+            "type": [Function],
+          },
+        ],
+        "type": [Function],
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <WithStyles(IconButton)
+            aria-label="Menu"
+            colors="inherit"
+            onClick={[Function]}
+>
+            <pure(Menu) />
+</WithStyles(IconButton)>,
+          <WithStyles(Drawer)
+            onClose={[Function]}
+            open={true}
+>
+            <div
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="button"
+                        style={
+                                    Object {
+                                                "paddingTop": "1rem",
+                                                "width": 250,
+                                              }
+                        }
+                        tabIndex={0}
+            />
+            <Collapsible
+                        expanded={[Function]}
+                        id="1"
+                        open={false}
+                        title="Voyage"
+            >
+                        <Collapsible
+                                    expanded={[Function]}
+                                    id="10"
+                                    open={false}
+                                    title="About this Wiki"
+                        >
+                                    <styled.li
+                                                onClick={[Function]}
+                                    >
+                                                <Styled(NavLink)
+                                                            to="/cms/100"
+                                                >
+                                                            Home
+                                                </Styled(NavLink)>
+                                    </styled.li>
+                                    <styled.li
+                                                onClick={[Function]}
+                                    >
+                                                <Styled(NavLink)
+                                                            to="/cms/101"
+                                                >
+                                                            How to Contribute
+                                                </Styled(NavLink)>
+                                    </styled.li>
+                        </Collapsible>
+                        <Collapsible
+                                    expanded={[Function]}
+                                    id="11"
+                                    open={false}
+                                    title="About Voyages"
+                        >
+                                    <styled.li
+                                                onClick={[Function]}
+                                    >
+                                                <Styled(NavLink)
+                                                            to="/cms/102"
+                                                >
+                                                            Voyage Roadmap
+                                                </Styled(NavLink)>
+                                    </styled.li>
+                        </Collapsible>
+                        <styled.li
+                                    onClick={[Function]}
+                        >
+                                    <Styled(NavLink)
+                                                to="/cms/103"
+                                    >
+                                                Introduction
+                                    </Styled(NavLink)>
+                        </styled.li>
+            </Collapsible>
+</WithStyles(Drawer)>,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "aria-label": "Menu",
+            "children": <pure(Menu) />,
+            "colors": "inherit",
+            "onClick": [Function],
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {},
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "children": Array [
+              <div
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                style={
+                                Object {
+                                                "paddingTop": "1rem",
+                                                "width": 250,
+                                              }
+                }
+                tabIndex={0}
+/>,
+              Array [
+                <Collapsible
+                  expanded={[Function]}
+                  id="1"
+                  open={false}
+                  title="Voyage"
+>
+                  <Collapsible
+                                    expanded={[Function]}
+                                    id="10"
+                                    open={false}
+                                    title="About this Wiki"
+                  >
+                                    <styled.li
+                                                      onClick={[Function]}
+                                    >
+                                                      <Styled(NavLink)
+                                                                        to="/cms/100"
+                                                      >
+                                                                        Home
+                                                      </Styled(NavLink)>
+                                    </styled.li>
+                                    <styled.li
+                                                      onClick={[Function]}
+                                    >
+                                                      <Styled(NavLink)
+                                                                        to="/cms/101"
+                                                      >
+                                                                        How to Contribute
+                                                      </Styled(NavLink)>
+                                    </styled.li>
+                  </Collapsible>
+                  <Collapsible
+                                    expanded={[Function]}
+                                    id="11"
+                                    open={false}
+                                    title="About Voyages"
+                  >
+                                    <styled.li
+                                                      onClick={[Function]}
+                                    >
+                                                      <Styled(NavLink)
+                                                                        to="/cms/102"
+                                                      >
+                                                                        Voyage Roadmap
+                                                      </Styled(NavLink)>
+                                    </styled.li>
+                  </Collapsible>
+                  <styled.li
+                                    onClick={[Function]}
+                  >
+                                    <Styled(NavLink)
+                                                      to="/cms/103"
+                                    >
+                                                      Introduction
+                                    </Styled(NavLink)>
+                  </styled.li>
+</Collapsible>,
+              ],
+            ],
+            "onClose": [Function],
+            "open": true,
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "onClick": [Function],
+                "onKeyDown": [Function],
+                "role": "button",
+                "style": Object {
+                  "paddingTop": "1rem",
+                  "width": 250,
+                },
+                "tabIndex": 0,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": "div",
+            },
+            Object {
+              "instance": null,
+              "key": "13",
+              "nodeType": "class",
+              "props": Object {
+                "children": Array [
+                  <Collapsible
+                    expanded={[Function]}
+                    id="10"
+                    open={false}
+                    title="About this Wiki"
+>
+                    <styled.li
+                                        onClick={[Function]}
+                    >
+                                        <Styled(NavLink)
+                                                            to="/cms/100"
+                                        >
+                                                            Home
+                                        </Styled(NavLink)>
+                    </styled.li>
+                    <styled.li
+                                        onClick={[Function]}
+                    >
+                                        <Styled(NavLink)
+                                                            to="/cms/101"
+                                        >
+                                                            How to Contribute
+                                        </Styled(NavLink)>
+                    </styled.li>
+</Collapsible>,
+                  <Collapsible
+                    expanded={[Function]}
+                    id="11"
+                    open={false}
+                    title="About Voyages"
+>
+                    <styled.li
+                                        onClick={[Function]}
+                    >
+                                        <Styled(NavLink)
+                                                            to="/cms/102"
+                                        >
+                                                            Voyage Roadmap
+                                        </Styled(NavLink)>
+                    </styled.li>
+</Collapsible>,
+                  <styled.li
+                    onClick={[Function]}
+>
+                    <Styled(NavLink)
+                                        to="/cms/103"
+                    >
+                                        Introduction
+                    </Styled(NavLink)>
+</styled.li>,
+                ],
+                "expanded": [Function],
+                "id": "1",
+                "open": false,
+                "title": "Voyage",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": "9",
+                  "nodeType": "class",
+                  "props": Object {
+                    "children": Array [
+                      <styled.li
+                        onClick={[Function]}
+>
+                        <Styled(NavLink)
+                                                to="/cms/100"
+                        >
+                                                Home
+                        </Styled(NavLink)>
+</styled.li>,
+                      <styled.li
+                        onClick={[Function]}
+>
+                        <Styled(NavLink)
+                                                to="/cms/101"
+                        >
+                                                How to Contribute
+                        </Styled(NavLink)>
+</styled.li>,
+                    ],
+                    "expanded": [Function],
+                    "id": "10",
+                    "open": false,
+                    "title": "About this Wiki",
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": "7",
+                      "nodeType": "class",
+                      "props": Object {
+                        "children": <Styled(NavLink)
+                          to="/cms/100"
+>
+                          Home
+</Styled(NavLink)>,
+                        "onClick": [Function],
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "children": "Home",
+                          "to": "/cms/100",
+                        },
+                        "ref": null,
+                        "rendered": "Home",
+                        "type": [Function],
+                      },
+                      "type": [Function],
+                    },
+                    Object {
+                      "instance": null,
+                      "key": "8",
+                      "nodeType": "class",
+                      "props": Object {
+                        "children": <Styled(NavLink)
+                          to="/cms/101"
+>
+                          How to Contribute
+</Styled(NavLink)>,
+                        "onClick": [Function],
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "children": "How to Contribute",
+                          "to": "/cms/101",
+                        },
+                        "ref": null,
+                        "rendered": "How to Contribute",
+                        "type": [Function],
+                      },
+                      "type": [Function],
+                    },
+                  ],
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "11",
+                  "nodeType": "class",
+                  "props": Object {
+                    "children": Array [
+                      <styled.li
+                        onClick={[Function]}
+>
+                        <Styled(NavLink)
+                                                to="/cms/102"
+                        >
+                                                Voyage Roadmap
+                        </Styled(NavLink)>
+</styled.li>,
+                    ],
+                    "expanded": [Function],
+                    "id": "11",
+                    "open": false,
+                    "title": "About Voyages",
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": "10",
+                      "nodeType": "class",
+                      "props": Object {
+                        "children": <Styled(NavLink)
+                          to="/cms/102"
+>
+                          Voyage Roadmap
+</Styled(NavLink)>,
+                        "onClick": [Function],
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "children": "Voyage Roadmap",
+                          "to": "/cms/102",
+                        },
+                        "ref": null,
+                        "rendered": "Voyage Roadmap",
+                        "type": [Function],
+                      },
+                      "type": [Function],
+                    },
+                  ],
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": "12",
+                  "nodeType": "class",
+                  "props": Object {
+                    "children": <Styled(NavLink)
+                      to="/cms/103"
+>
+                      Introduction
+</Styled(NavLink)>,
+                    "onClick": [Function],
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "children": "Introduction",
+                      "to": "/cms/103",
+                    },
+                    "ref": null,
+                    "rendered": "Introduction",
+                    "type": [Function],
+                  },
+                  "type": [Function],
+                },
+              ],
+              "type": [Function],
+            },
+          ],
+          "type": [Function],
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;

--- a/frontend/src/Sidebar/__snapshots__/utils.test.js.snap
+++ b/frontend/src/Sidebar/__snapshots__/utils.test.js.snap
@@ -1,5 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should create expanded tree if id present 1`] = `
+Array [
+  <Collapsible
+    expanded={[Function]}
+    id="1"
+    open={true}
+    title="Voyage"
+>
+    <Collapsible
+        expanded={[Function]}
+        id="10"
+        open={true}
+        title="About this Wiki"
+    >
+        <styled.li
+            onClick={[Function]}
+        >
+            <Styled(NavLink)
+                to="/cms/100"
+            >
+                Home
+            </Styled(NavLink)>
+        </styled.li>
+        <styled.li
+            onClick={[Function]}
+        >
+            <Styled(NavLink)
+                to="/cms/101"
+            >
+                How to Contribute
+            </Styled(NavLink)>
+        </styled.li>
+    </Collapsible>
+    <Collapsible
+        expanded={[Function]}
+        id="11"
+        open={false}
+        title="About Voyages"
+    >
+        <styled.li
+            onClick={[Function]}
+        >
+            <Styled(NavLink)
+                to="/cms/102"
+            >
+                Voyage Roadmap
+            </Styled(NavLink)>
+        </styled.li>
+    </Collapsible>
+    <styled.li
+        onClick={[Function]}
+    >
+        <Styled(NavLink)
+            to="/cms/103"
+        >
+            Introduction
+        </Styled(NavLink)>
+    </styled.li>
+</Collapsible>,
+]
+`;
+
 exports[`should create html tree from articles 1`] = `
 Array [
   <Collapsible

--- a/frontend/src/Sidebar/__snapshots__/utils.test.js.snap
+++ b/frontend/src/Sidebar/__snapshots__/utils.test.js.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should create html tree from articles 1`] = `
+Array [
+  <Collapsible
+    expanded={[Function]}
+    id="1"
+    open={false}
+    title="Voyage"
+>
+    <Collapsible
+        expanded={[Function]}
+        id="10"
+        open={false}
+        title="About this Wiki"
+    >
+        <styled.li
+            onClick={[Function]}
+        >
+            <Styled(NavLink)
+                to="/cms/100"
+            >
+                Home
+            </Styled(NavLink)>
+        </styled.li>
+        <styled.li
+            onClick={[Function]}
+        >
+            <Styled(NavLink)
+                to="/cms/101"
+            >
+                How to Contribute
+            </Styled(NavLink)>
+        </styled.li>
+    </Collapsible>
+    <Collapsible
+        expanded={[Function]}
+        id="11"
+        open={false}
+        title="About Voyages"
+    >
+        <styled.li
+            onClick={[Function]}
+        >
+            <Styled(NavLink)
+                to="/cms/102"
+            >
+                Voyage Roadmap
+            </Styled(NavLink)>
+        </styled.li>
+    </Collapsible>
+    <styled.li
+        onClick={[Function]}
+    >
+        <Styled(NavLink)
+            to="/cms/103"
+        >
+            Introduction
+        </Styled(NavLink)>
+    </styled.li>
+</Collapsible>,
+]
+`;

--- a/frontend/src/Sidebar/expandTree.js
+++ b/frontend/src/Sidebar/expandTree.js
@@ -1,0 +1,21 @@
+const expandTree = (tree, id, expanded) => {
+  const copy = {};
+  const keys = Object.keys(tree);
+  keys.forEach(k => {
+    if (typeof tree[k] === 'string') {
+      copy[k] = tree[k];
+      if (k === '_id') {
+        if (tree._id === id) {
+          copy.expanded = expanded;
+        } else {
+          copy.expanded = tree.expanded;
+        }
+      }
+    } else if (typeof tree[k] === 'object') {
+      copy[k] = expandTree(tree[k], id, expanded);
+    }
+  });
+  return copy;
+};
+
+export default expandTree;

--- a/frontend/src/Sidebar/expandTree.test.js
+++ b/frontend/src/Sidebar/expandTree.test.js
@@ -1,0 +1,119 @@
+import expandTree from './expandTree';
+
+const testTree1 = {
+  Voyage: {
+    _id: '1',
+    expanded: false,
+    'About this Wiki': {
+      _id: '10',
+      expanded: false,
+      Home: '100',
+      'How to Contribute': '101',
+    },
+    'About Voyages': {
+      _id: '11',
+      expanded: false,
+      'Voyage Roadmap': '102',
+    },
+    Introduction: '103',
+  },
+};
+
+const expectedTree1 = {
+  Voyage: {
+    _id: '1',
+    expanded: true,
+    'About this Wiki': {
+      _id: '10',
+      expanded: false,
+      Home: '100',
+      'How to Contribute': '101',
+    },
+    'About Voyages': {
+      _id: '11',
+      expanded: false,
+      'Voyage Roadmap': '102',
+    },
+    Introduction: '103',
+  },
+};
+const expectedTree2 = {
+  Voyage: {
+    _id: '1',
+    expanded: false,
+    'About this Wiki': {
+      _id: '10',
+      expanded: false,
+      Home: '100',
+      'How to Contribute': '101',
+    },
+    'About Voyages': {
+      _id: '11',
+      expanded: true,
+      'Voyage Roadmap': '102',
+    },
+    Introduction: '103',
+  },
+};
+
+it('should set expanded', () => {
+  const tree = expandTree(testTree1, '1', true);
+  expect(tree).toEqual(expectedTree1);
+});
+it('should collapse correctly', () => {
+  const start = expandTree(testTree1, '1', true);
+  const end = expandTree(start, '1', false);
+  expect(end).toEqual(testTree1);
+});
+it('should set correct child expanded', () => {
+  const tree = expandTree(testTree1, '11', true);
+  expect(tree).toEqual(expectedTree2);
+});
+
+const testTree10 = {
+  Voyage: {
+    _id: '1',
+    expanded: true,
+    'About this Wiki': {
+      _id: '10',
+      expanded: false,
+      Home: '100',
+      'How to Contribute': '101',
+    },
+    'About Voyages': {
+      _id: '11',
+      expanded: false,
+      'Voyage Roadmap': '102',
+    },
+    Introduction: '103',
+  },
+};
+
+const expectedTree10 = {
+  Voyage: {
+    _id: '1',
+    expanded: true,
+    'About this Wiki': {
+      _id: '10',
+      expanded: true,
+      Home: '100',
+      'How to Contribute': '101',
+    },
+    'About Voyages': {
+      _id: '11',
+      expanded: false,
+      'Voyage Roadmap': '102',
+    },
+    Introduction: '103',
+  },
+};
+
+it('should expand without destroying current expansions', () => {
+  const tree = expandTree(testTree10, '10', true);
+  expect(tree).toEqual(expectedTree10);
+});
+it('should collapse without distroying existing tree', () => {
+  const start = expandTree(testTree10, '10', true);
+  const end = expandTree(start, '10', false);
+  expect(end).toEqual(testTree10);
+});

--- a/frontend/src/Sidebar/styled.js
+++ b/frontend/src/Sidebar/styled.js
@@ -1,4 +1,7 @@
+import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
+
+const activeClassName = 'selected';
 
 const $sidebarBackground = '#e2e2e2';
 
@@ -24,6 +27,22 @@ export const Wrapper = styled.nav`
 export const LI = styled.li`
   list-style-type: none;
   margin-left: 1rem;
+`;
+
+export const DrawerLink = styled(NavLink).attrs({
+  activeClassName,
+})`
+  color: #333;
+
+  &:hover {
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  &.${activeClassName} {
+    color: #333;
+    font-weight: 600;
+  }
 `;
 
 export default Wrapper;

--- a/frontend/src/Sidebar/styled.js
+++ b/frontend/src/Sidebar/styled.js
@@ -5,17 +5,18 @@ const activeClassName = 'selected';
 
 const $sidebarBackground = '#e2e2e2';
 
-export const Details = styled.details`
+export const Details = styled.div`
   cursor: default;
   margin-left: 1rem;
 `;
 
-export const Summary = styled.summary`
+export const Summary = styled.div`
   outline: none;
+  margin-top: 0.3rem;
 `;
 
 export const Wrapper = styled.nav`
-  padding: 2em 2em;
+  padding: 1em 1em;
   background-color: ${$sidebarBackground};
   display: flex;
   flex-direction: column;
@@ -26,6 +27,7 @@ export const Wrapper = styled.nav`
 
 export const LI = styled.li`
   list-style-type: none;
+  padding-top: 0.2rem;
   margin-left: 1rem;
 `;
 

--- a/frontend/src/Sidebar/utils.js
+++ b/frontend/src/Sidebar/utils.js
@@ -51,7 +51,7 @@ export const getTree = articles => {
     if (!tree[article.topic.name]) {
       tree[article.topic.name] = {
         _id: article.topic._id,
-        expanded: article.topic.expanded,
+        expanded: false,
       };
     }
     let topic = tree[article.topic.name];
@@ -61,7 +61,7 @@ export const getTree = articles => {
         if (!topic[sub]) {
           topic[sub] = {
             _id: article.sub_topic._id,
-            expanded: article.sub_topic.expanded,
+            expanded: false,
           };
         }
         topic = topic[sub];

--- a/frontend/src/Sidebar/utils.js
+++ b/frontend/src/Sidebar/utils.js
@@ -27,7 +27,7 @@ const getTree = articles => {
 
 let ndx = 0;
 /* eslint-disable no-plusplus */
-const getChildren = (sub, path) => {
+const getChildren = (sub, path, onArticleSelect) => {
   const keys = Object.keys(sub);
   return keys.map(key => {
     const s = sub[key];
@@ -35,12 +35,12 @@ const getChildren = (sub, path) => {
       // TODO: great idea but keeping it updated will be fun
       // const displayed = path.includes(key) ? ' >' : '';
       return (
-        <LI key={ndx++}>
+        <LI key={ndx++} onClick={onArticleSelect}>
           <DrawerLink to={`/cms/${s}`}>{`${key}`}</DrawerLink>
         </LI>
       );
     }
-    const children = getChildren(sub[key], path);
+    const children = getChildren(sub[key], path, onArticleSelect);
     const open = path.includes(key);
     return (
       <Collapsible key={ndx++} title={key} open={open}>

--- a/frontend/src/Sidebar/utils.js
+++ b/frontend/src/Sidebar/utils.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Collapsible from './Collapsible';
 import { LI, DrawerLink } from './styled';
 
-const getTree = articles => {
+export const getTree = articles => {
   const tree = {};
   articles.forEach(article => {
     if (!tree[article.topic.name]) {
@@ -26,7 +26,7 @@ const getTree = articles => {
 
 let ndx = 0;
 /* eslint-disable no-plusplus */
-const getChildren = (sub, path, onArticleSelect) => {
+export const getChildren = (sub, path, onArticleSelect) => {
   const keys = Object.keys(sub);
   return keys.map(key => {
     const s = sub[key];

--- a/frontend/src/Sidebar/utils.js
+++ b/frontend/src/Sidebar/utils.js
@@ -122,7 +122,6 @@ const buildHtml = (articles, articleTree, id, onArticleSelect, onExpand) => {
       /* eslint-enalbe camelcase */
     }
   }
-  // const tree = getTree(articles);
   const articlesHtml = getChildren(
     articleTree,
     selectedArticlePath,

--- a/frontend/src/Sidebar/utils.js
+++ b/frontend/src/Sidebar/utils.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 
 import Collapsible from './Collapsible';
-import { LI } from './styled';
+import { LI, DrawerLink } from './styled';
 
 const getTree = articles => {
   const tree = {};
@@ -37,7 +36,7 @@ const getChildren = (sub, path) => {
       // const displayed = path.includes(key) ? ' >' : '';
       return (
         <LI key={ndx++}>
-          <Link to={`/cms/${s}`}>{`${key}`}</Link>
+          <DrawerLink to={`/cms/${s}`}>{`${key}`}</DrawerLink>
         </LI>
       );
     }

--- a/frontend/src/Sidebar/utils.js
+++ b/frontend/src/Sidebar/utils.js
@@ -19,7 +19,6 @@ const getTree = articles => {
         topic = topic[sub];
       });
     }
-    // topic.article = { title: article.title, _id : article._id };
     topic[article.title] = article._id;
   });
   return tree;
@@ -51,4 +50,25 @@ const getChildren = (sub, path, onArticleSelect) => {
 };
 /* eslint-enable no-plusplus */
 
-export { getTree, getChildren };
+const buildTree = (articles, id, onArticleSelect) => {
+  let selectedArticlePath = [];
+  if (id) {
+    const selectedArticles = articles.filter(article => article._id === id);
+    if (selectedArticles.length) {
+      /* eslint-disable camelcase */
+      const { topic, sub_topic, title } = selectedArticles[0];
+      selectedArticlePath = [topic.name, title];
+      if (sub_topic) {
+        selectedArticlePath = selectedArticlePath.concat(
+          sub_topic.name.split('>')
+        );
+      }
+      /* eslint-enalbe camelcase */
+    }
+  }
+  const tree = getTree(articles);
+  const articlesHtml = getChildren(tree, selectedArticlePath, onArticleSelect);
+  return articlesHtml;
+};
+
+export default buildTree;

--- a/frontend/src/Sidebar/utils.js
+++ b/frontend/src/Sidebar/utils.js
@@ -91,7 +91,6 @@ export const getChildren = (sub, path, onArticleSelect, onExpand) => {
     const children = getChildren(sub[key], path, onArticleSelect, onExpand);
 
     const open = sub[key].expanded || path.includes(key);
-    console.log('open expanded, path, key:', open, sub[key].expanded, path, key);
     return acc.concat(
       <Collapsible
         key={ndx++}
@@ -111,7 +110,6 @@ const buildHtml = (articles, articleTree, id, onArticleSelect, onExpand) => {
   let selectedArticlePath = [];
   if (id) {
     const selectedArticles = articles.filter(article => article._id === id);
-    console.log('article list, selected article id, found:', articles, id, selectedArticles);
     if (selectedArticles.length) {
       /* eslint-disable camelcase */
       const { topic, sub_topic, title } = selectedArticles[0];

--- a/frontend/src/Sidebar/utils.js
+++ b/frontend/src/Sidebar/utils.js
@@ -4,6 +4,19 @@ import Collapsible from './Collapsible';
 
 import { LI, DrawerLink } from './styled';
 
+export const checkMobile = (mobile, windowWidth) => {
+  const BREAK_MOBILE = 900;
+
+  if (
+    (mobile && windowWidth > BREAK_MOBILE) ||
+    (!mobile && windowWidth <= BREAK_MOBILE)
+  ) {
+    return !mobile;
+  }
+
+  return mobile;
+};
+
 /* eslint-disable spaced-comment */
 /******************************************************************************
 

--- a/frontend/src/Sidebar/utils.test.js
+++ b/frontend/src/Sidebar/utils.test.js
@@ -70,3 +70,9 @@ it('should create html tree from articles', () => {
   const html = buildHtml(articles, articleTree, '', onArticleSelect, onExpand);
   expect(html).toMatchSnapshot();
 });
+
+it('should create expanded tree if id present', () => {
+  const articleTree = getTree(articles);
+  const html = buildHtml(articles, articleTree, '101', onArticleSelect, onExpand);
+  expect(html).toMatchSnapshot();
+});

--- a/frontend/src/Sidebar/utils.test.js
+++ b/frontend/src/Sidebar/utils.test.js
@@ -1,0 +1,48 @@
+import buildHtml, { getTree } from './utils';
+
+const topics = [{ _id: '1', name: 'Voyage', order: 1 }];
+// eslint-disable-next-line camelcase
+const sub_topics = [
+  { _id: '10', parent: '1', name: 'About this Wiki', order: 1 },
+  { _id: '11', parent: '1', name: 'About Voyages', order: 2 },
+];
+
+/* eslint-disable prettier/prettier */
+const articles = [
+  { _id: '100', topic: topics[0], sub_topic: sub_topics[0], title: 'Home', order: 1 },
+  { _id: '101', topic: topics[0], sub_topic: sub_topics[0], title: 'How to Contribute', order: 2 },
+  { _id: '102', topic: topics[0], sub_topic: sub_topics[1], title: 'Voyage Roadmap', order: 1 },
+  { _id: '103', topic: topics[0], sub_topic: null, title: 'Introduction', order: 1 },
+];
+const expectedTree = {
+  Voyage: {
+    _id: '1',
+    expanded: false,
+    'About this Wiki': {
+      _id: '10',
+      expanded: false,
+      Home: '100',
+      'How to Contribute': '101',
+    },
+    'About Voyages': {
+      _id: '11',
+      expanded: false,
+      'Voyage Roadmap': '102',
+    },
+    Introduction: '103',
+  },
+};
+
+it('should create article tree', () => {
+  const articleTree = getTree(articles);
+  expect(articleTree).toEqual(expectedTree);
+});
+
+const onArticleSelect = () => {};
+const onExpand = () => {};
+
+it('should create html tree from articles', () => {
+  const articleTree = getTree(articles);
+  const html = buildHtml(articles, articleTree, '', onArticleSelect, onExpand);
+  expect(html).toMatchSnapshot();
+});

--- a/frontend/src/Sidebar/utils.test.js
+++ b/frontend/src/Sidebar/utils.test.js
@@ -9,10 +9,34 @@ const sub_topics = [
 
 /* eslint-disable prettier/prettier */
 const articles = [
-  { _id: '100', topic: topics[0], sub_topic: sub_topics[0], title: 'Home', order: 1 },
-  { _id: '101', topic: topics[0], sub_topic: sub_topics[0], title: 'How to Contribute', order: 2 },
-  { _id: '102', topic: topics[0], sub_topic: sub_topics[1], title: 'Voyage Roadmap', order: 1 },
-  { _id: '103', topic: topics[0], sub_topic: null, title: 'Introduction', order: 1 },
+  {
+    _id: '100',
+    topic: topics[0],
+    sub_topic: sub_topics[0],
+    title: 'Home',
+    order: 1,
+  },
+  {
+    _id: '101',
+    topic: topics[0],
+    sub_topic: sub_topics[0],
+    title: 'How to Contribute',
+    order: 2,
+  },
+  {
+    _id: '102',
+    topic: topics[0],
+    sub_topic: sub_topics[1],
+    title: 'Voyage Roadmap',
+    order: 1,
+  },
+  {
+    _id: '103',
+    topic: topics[0],
+    sub_topic: null,
+    title: 'Introduction',
+    order: 1,
+  },
 ];
 const expectedTree = {
   Voyage: {

--- a/frontend/src/Sidebar/utils.test.js
+++ b/frontend/src/Sidebar/utils.test.js
@@ -100,4 +100,4 @@ describe('mobile checks', () => {
     const mobile = checkMobile(true, 1000);
     expect(mobile).toBe(false);
   });
-})
+});

--- a/frontend/src/Sidebar/utils.test.js
+++ b/frontend/src/Sidebar/utils.test.js
@@ -1,4 +1,4 @@
-import buildHtml, { getTree } from './utils';
+import buildHtml, { getTree, checkMobile } from './utils';
 
 const topics = [{ _id: '1', name: 'Voyage', order: 1 }];
 // eslint-disable-next-line camelcase
@@ -73,6 +73,31 @@ it('should create html tree from articles', () => {
 
 it('should create expanded tree if id present', () => {
   const articleTree = getTree(articles);
-  const html = buildHtml(articles, articleTree, '101', onArticleSelect, onExpand);
+  const html = buildHtml(
+    articles,
+    articleTree,
+    '101',
+    onArticleSelect,
+    onExpand
+  );
   expect(html).toMatchSnapshot();
 });
+
+describe('mobile checks', () => {
+  it('should set mobile for with < 900', () => {
+    const mobile = checkMobile(false, 400);
+    expect(mobile).toBe(true);
+  });
+  it('should set mobile if mobile is already set', () => {
+    const mobile = checkMobile(true, 400);
+    expect(mobile).toBe(true);
+  });
+  it('should set not mobile for width > 900', () => {
+    const mobile = checkMobile(false, 1000);
+    expect(mobile).toBe(false);
+  });
+  it('should set not mobile when mobile is set and width > 900', () => {
+    const mobile = checkMobile(true, 1000);
+    expect(mobile).toBe(false);
+  });
+})


### PR DESCRIPTION
supercedes pr 132 fix/mobile-sidebar.

Major changes to sidebar so we don't lose tree state after hiding the material-ui drawer (mobile only).
Slimmed down CMSContainer component.
Html element details/summary didn't work as a controlled component so replace with home grown version.
Move Collapsible test to utils (as that's where they belong) and create a new Collapsible specific snapshot test.
Create tests for CMSContainer and add tests to Sidebar and Sidebar utils.