### PR TITLE
Fix props warning on login page

### DIFF
--- a/frontend/src/Login/Login.js
+++ b/frontend/src/Login/Login.js
@@ -254,7 +254,7 @@ class Login extends React.Component {
           open={message.show}
           onClose={this.handleClose}
           autoHideDuration={3000}
-          SnackbarContentProps={{
+          ContentProps={{
             'aria-describedby': 'message-id',
           }}
           message={

--- a/frontend/src/common/MessageBar.js
+++ b/frontend/src/common/MessageBar.js
@@ -15,7 +15,7 @@ const MessageBar = ({ anchor, message, handleClose }) => (
     open={message.show}
     onClose={handleClose}
     autoHideDuration={message.error ? null : 3000}
-    SnackbarContentProps={{
+    ContentProps={{
       'aria-describedby': 'message-id',
     }}
     message={


### PR DESCRIPTION
Apparently missed this prop change when updated Material-UI to v1.
Closes #147.