### PR TITLE
test: non-existant-leaf returns null

### DIFF
--- a/frontend/src/Sidebar/findLeafPath.test.js
+++ b/frontend/src/Sidebar/findLeafPath.test.js
@@ -139,6 +139,10 @@ const tree = {
 /* eslint-enable */
 
 describe('find tree path for leaf', () => {
+  it('should not find non-existant path', () => {
+    const path = findLeafPath(tree, 'non-existant');
+    expect(path).toBeNull();
+  });
   it('should find path', () => {
     let path = findLeafPath(tree, '5b1983cfbb796d2be9f7cf0a');
     expect(path).toEqual([


### PR DESCRIPTION
added a test to check non-existant article id returns null from findLeapPath